### PR TITLE
Fix package detection and installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,17 +51,8 @@ documentation = "https://basicrta.readthedocs.io"
 [tool.setuptools]
 py-modules = []
 
-[tool.pytest.ini_options]
-minversion = "8.0"
-testpaths = [
-    "basicrta/tests",
-]
-pythonpath = [
-    "basicrta",
-    "tests",
-    "."
-]
-
+[tool.setuptools.packages]
+find = {}
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
`basicrta` was not being installed correctly, leading to import errors. Specify `tool.setuptools.packages.find` to automatically find the package and install correctly.

I tested the behavior with code similar to the below code block. Prior to these changes, the `import basicrta` failed.

```
micromamba create -p ./env/ python=3.12 -y
micromamba -p ./env/ run pip install ".[test]"

mkdir tmp/ # make sure we can import basicrta outside of the current directory
cd tmp/ && micromamba -p ../env/ run python -c "import basicrta; print(basicrta)"
cd ..
micromamba -p env/ run pytest -v basicrta/tests/ # confirm tests still pass
```