### PR TITLE
fix handling of gskip in cluster-py --gskip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,13 @@ The rules for this file:
   set the default to 100 (as in the paper) and ensure that the correct value
   is used as Gibbs.gskip (which is relative to the save skip step of Gibbs.g)
   (Issue #48)
-  
+
+### Changed
+* Default kwargs for the skipping in the Gibbs sampler are now
+  gibbs.Gibbs(g=100, gskip=1) (used to be g=50, gskip=2) but for most users
+  gskip for processing data is not important and it makes more sense to focus 
+  on g as the stride at which we sample AND process data (#48, PR #49)
+
 
 ## [1.1.2] - 2025-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The rules for this file:
 
 ### Authors
 * @orbeckst
+* @rjoshi44
 
 ### Fixed
 * Fixed setting of gskip in ProcessProtein/cluster.py command line interface:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ The rules for this file:
     * YYYY-MM-DD date format (following ISO 8601)
   * accompany each entry with github issue/PR number (Issue #xyz)
 -->
+## [1.1.3] - UNRELEASES
+
+### Authors
+* @orbeckst
+
+### Fixed
+* Fixed setting of gskip in ProcessProtein/cluster.py command line interface:
+  set the default to 100 (as in the paper) and ensure that the correct value
+  is used as Gibbs.gskip (which is relative to the save skip step of Gibbs.g)
+  (Issue #48)
+  
+
 ## [1.1.2] - 2025-07-22
 
 ### Authors

--- a/basicrta/cluster.py
+++ b/basicrta/cluster.py
@@ -71,8 +71,8 @@ class ProcessProtein(object):
                     if ggskip < 1:
                         ggskip = 1
                         warnings.warn(f"WARNING: gskip={self.gskip} is less than g={g.g}, setting gskip to 1")
-                    # NOTE:Gibbs.gskip is the multiplier for Gibbs.g (the save interval) and the gskip
-                    # here is the total skip interval for the Gibbs sampler: gskip = g.g * g.gskip
+                    # NOTE: Gibbs samples are saved every g.g steps, then sub-sampled by g.gskip
+                    # Total skip interval = g.g * g.gskip, giving niter // (g.g * g.gskip) independent samples
                     g.gskip = ggskip       # process every g.g * g.gskip samples from full chain
                     g.burnin = self.burnin
                     g.process_gibbs()
@@ -252,6 +252,5 @@ if __name__ == "__main__":  #pragma: no cover
     pp = ProcessProtein(args.niter, args.prot, args.cutoff, 
                         gskip=args.gskip, burnin=args.burnin)
     pp.reprocess(nproc=args.nproc)
-    pp.get_taus()
     pp.write_data()
     pp.plot_protein(label_cutoff=args.label_cutoff)

--- a/basicrta/cluster.py
+++ b/basicrta/cluster.py
@@ -1,5 +1,6 @@
 import os
 import gc
+import warnings
 import numpy as np
 from tqdm import tqdm
 from multiprocessing import Pool, Lock
@@ -29,17 +30,21 @@ class ProcessProtein(object):
     :param cutoff: Cutoff used in contact analysis.
     :type cutoff: float
     :param gskip: Gibbs skip parameter for decorrelated samples;
+                  only save every `gskip` samples from full Gibbs sampler chain;
                   default from https://pubs.acs.org/doi/10.1021/acs.jctc.4c01522
+                  When the sampled Markov chain is loaded, then the output is already
+                  saved at every `Gibbs.g` samples. We calculate a new `gskip` value to 
+                  get close to the desired `gskip` value. 
     :type gskip: int
-    :param burnin: Burn-in parameter, drop first N samples as equilibration;
+    :param burnin: Burn-in parameter, drop first `burnin` samples as equilibration;
                    default from https://pubs.acs.org/doi/10.1021/acs.jctc.4c01522
     :type burnin: int
     """
     
     def __init__(self, niter, prot, cutoff, 
-                 gskip=1000, burnin=10000, 
+                 gskip=100, burnin=10000, 
                  taus=None, bars=None):
-        self.residues = Results() # TODO: double-check that we need to use this, it gets set in reprocess/get_taus
+        self.residues = None
         self.niter = niter
         self.prot = prot
         self.cutoff = cutoff
@@ -55,16 +60,23 @@ class ProcessProtein(object):
         if os.path.exists(f'{adir}/gibbs_{self.niter}.pkl'):
             result = f'{adir}/gibbs_{self.niter}.pkl'
             try:
-                result = f'{adir}/gibbs_{self.niter}.pkl'
                 g = Gibbs().load(result)
-                if process:
-                    g.gskip = self.gskip
-                    g.burnin = self.burnin
-                    g.process_gibbs()
-                tau = g.estimate_tau()
             except:
                 result = None
                 tau = [0, 0, 0]
+            else:
+                if process:
+                    # calculate the new g.gskip value:
+                    ggskip = self.gskip // g.g
+                    if ggskip < 1:
+                        ggskip = 1
+                        warnings.warn(f"WARNING: gskip={self.gskip} is less than g={g.g}, setting gskip to 1")
+                    # NOTE:Gibbs.gskip is the multiplier for Gibbs.g (the save interval) and the gskip
+                    # here is the total skip interval for the Gibbs sampler: gskip = g.g * g.gskip
+                    g.gskip = ggskip       # process every g.g * g.gskip samples from full chain
+                    g.burnin = self.burnin
+                    g.process_gibbs()
+                tau = g.estimate_tau()
         else:
             result = None
             tau = [0, 0, 0]
@@ -228,7 +240,7 @@ if __name__ == "__main__":  #pragma: no cover
             'LABEL-CUTOFF * <tau>. ')
     parser.add_argument('--structure', type=str, nargs='?')
     # use  for default values
-    parser.add_argument('--gskip', type=int, default=1000, 
+    parser.add_argument('--gskip', type=int, default=100, 
                         help='Gibbs skip parameter for decorrelated samples;'
                         'default from https://pubs.acs.org/doi/10.1021/acs.jctc.4c01522')
     parser.add_argument('--burnin', type=int, default=10000, 

--- a/basicrta/gibbs.py
+++ b/basicrta/gibbs.py
@@ -116,6 +116,23 @@ class Gibbs(object):
                    directory to load/save results. Allows for multiple cutoffs
                    to be tested in directory containing contacts.
     :type cutoff: float
+    :param g: Gibbs skip parameter for decorrelated samples;
+              only save every `g` samples from full Gibbs sampler chain;
+              default from https://pubs.acs.org/doi/10.1021/acs.jctc.4c01522
+              (NOTE: this value is called *gskip* in cluster.py)
+    :type g: int
+    :param burnin: Burn-in parameter, drop first `burnin` samples as equilibration;
+                   default from https://pubs.acs.org/doi/10.1021/acs.jctc.4c01522
+    :type burnin: int
+    :param gskip: Process data from the subsampled chain (ever `g` samples) at a 
+                  coarser skip interval of `gskip` samples. Thus, in total, samples
+                  are taken at ``g * gskip`` steps from the full chain.
+                  (This is useful for sensitivity analysis where we run the chain with 
+                  a small `g` value and save many samples and then use `gskip` to process
+                  samples at increasingly larger intervals without having to re-run the 
+                  chain.) The default value of 1 means that the samples are processed at
+                  every `g` samples from the full chain.
+    :type gskip: int
 
     EXAMPLE
     -------
@@ -139,7 +156,7 @@ class Gibbs(object):
     """
 
     def __init__(self, times=None, residue=None, loc=0, ncomp=15, niter=110000,
-                 cutoff=None, g=50, burnin=10000, gskip=2):
+                 cutoff=None, g=100, burnin=10000, gskip=1):
         self.times = times
         self.residue = residue
         self.niter = niter

--- a/basicrta/tests/test_combine_contacts.py
+++ b/basicrta/tests/test_combine_contacts.py
@@ -265,6 +265,8 @@ class TestCombineContacts:
             ncomp=2,  # Use 2 components for stability
             niter=1000,  # 1000 steps as requested
             burnin=5,   # 5 burnin steps as requested
+            g=50,
+            gskip=1,
             cutoff=7.0  # Set cutoff for directory creation
         )
         

--- a/basicrta/tests/test_gibbs.py
+++ b/basicrta/tests/test_gibbs.py
@@ -127,6 +127,16 @@ class TestGibbsSampler:
             'cutoff': 7.0,
             'g': 100
         },
+        {
+            'times': None,  # Will be set from fixture
+            'residue': 'W313',
+            'ncomp': 2,
+            'niter': 1000,
+            'burnin': 5,
+            'cutoff': 7.0,
+            'g': 50,
+            'gskip': 2
+        },        
     ])
     def test_gibbs_run_method(self, tmp_path, synthetic_timeseries, init_kwargs):
         """Test the run() method for Gibbs class with synthetic data."""


### PR DESCRIPTION


<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #48

Changes made in this Pull Request:
- corrected default value to 100 (instead of 1000)
- fixed passing of gskip value; Gibbs.gskip is a multiple of the save skip value Gibbs.g. If g is given and the user requested gskip is smaller than g, a warning is emitted and the Gibbs.gskip value is set to 1.
- updated tests


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
