### PR TITLE
let cluster.ProcessProtein.reprocess() skip residues with insufficien…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ The rules for this file:
     * YYYY-MM-DD date format (following ISO 8601)
   * accompany each entry with github issue/PR number (Issue #xyz)
 -->
+## [1.1.4] - unpublished
+
+### Authors
+* @orbeckst
+
+### Fixed
+* Have cluster.ProcessProtein.reprocess() record "no result" if
+  the gibbs.Gibbs.process_gibbs() step fails due to insufficient 
+  number of samples. Otherwise `python -m cluster` fails to process
+  whole proteins.
+
 ## [1.1.3] - 2025-09-11
 
 ### Authors

--- a/basicrta/cluster.py
+++ b/basicrta/cluster.py
@@ -75,9 +75,22 @@ class ProcessProtein(object):
                     # Total skip interval = g.g * g.gskip, giving niter // (g.g * g.gskip) independent samples
                     g.gskip = ggskip       # process every g.g * g.gskip samples from full chain
                     g.burnin = self.burnin
-                    g.process_gibbs()
-                tau = g.estimate_tau()
+                    try:
+                        g.process_gibbs()
+                    except ValueError:
+                        # HACK: triggered when we do not have enough samples for clustering
+                        # TODO: make sure elsewhere that we do not save pickle files
+                        #       with insufficient data
+                        # TODO: use a logger and say that we failed for this residue even though
+                        #       sampler data was (supposedly) available
+                        result = None
+                        tau = [0, 0, 0]
+                    else:
+                        tau = g.estimate_tau()
+                else:
+                    tau = g.estimate_tau()
         else:
+            # if the pkl files do not exist
             result = None
             tau = [0, 0, 0]
 


### PR DESCRIPTION
Fixes #

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
* Have cluster.ProcessProtein.reprocess() record "no result" if
  the gibbs.Gibbs.process_gibbs() step fails due to insufficient
  number of samples. Otherwise `python -m cluster` fails to process
  whole proteins.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [ ] Issue raised/referenced?
